### PR TITLE
fixes to get EngineCoreDef to be a custom component

### DIFF
--- a/source/Control.cs
+++ b/source/Control.cs
@@ -108,6 +108,7 @@ namespace CustomComponents
             }
         }
 
+        private static readonly Regex CustomTypeRegex = new Regex(@"""CustomType""\s*:\s*""([^""]+)""", RegexOptions.Compiled);
 
         public static bool LoaderPatch<T>(DataManager.ResourceLoadRequest<T> loader,
             string json, ref T resource)
@@ -117,11 +118,11 @@ namespace CustomComponents
 
             //Control.mod.Logger.Log("loading " + (id.Success ? id.Result("$1") : "not found"));
 
-            var custom = Regex.Match(json, "\"CustomType\" : \"(.+?)\"");
+            var custom = CustomTypeRegex.Match(json);
             if (!custom.Success)
                 return true;
 
-            string custom_type = custom.Result("$1");
+            string custom_type = custom.Groups[1].Value;
 
             Logger.LogDebug("Loading custom: " + custom_type);
 

--- a/source/CustomComponent.cs
+++ b/source/CustomComponent.cs
@@ -11,6 +11,8 @@ namespace CustomComponents
         string CustomType { get; }
         void FromJson(string json);
         string ToJson();
+
+        Type TooltipType { get; }
     }
 
     /// <summary>
@@ -47,4 +49,3 @@ namespace CustomComponents
         }
     }
 }
-

--- a/source/CustomComponents.csproj
+++ b/source/CustomComponents.csproj
@@ -83,6 +83,7 @@
     <Compile Include="CustomTypes\CustomJumpJetDef.cs" />
     <Compile Include="CustomTypes\CustomWeaponDef.cs" />
     <Compile Include="CustomTypes\CustomHeatSinkDef.cs" />
+    <Compile Include="Tooltips.cs" />
     <Compile Include="Validators\LocationHelper.cs" />
     <Compile Include="Validators\MechLabHelper.cs" />
     <Compile Include="Validators\ValidatorInterfaces.cs" />

--- a/source/CustomTypes/CustomAmmunitionBoxDef.cs
+++ b/source/CustomTypes/CustomAmmunitionBoxDef.cs
@@ -29,6 +29,8 @@ namespace CustomComponents
         {
             return JSONSerializationUtility.ToJSON<T>(this as T);
         }
+
+        public Type TooltipType => TooltipHelper.GetTooltipType(new AmmunitionBoxDef());
     }
 
     [Custom("CategoryAmmunitionBox")]

--- a/source/CustomTypes/CustomHeatSinkDef.cs
+++ b/source/CustomTypes/CustomHeatSinkDef.cs
@@ -1,4 +1,5 @@
-﻿using BattleTech;
+﻿using System;
+using BattleTech;
 using BattleTech.UI;
 using HBS.Util;
 
@@ -23,6 +24,8 @@ namespace CustomComponents
         {
             return JSONSerializationUtility.ToJSON<T>(this as T);
         }
+
+        public Type TooltipType => TooltipHelper.GetTooltipType(new HeatSinkDef());
     }
 
     [Custom("CategoryHeatSink")]

--- a/source/CustomTypes/CustomJumpJetDef.cs
+++ b/source/CustomTypes/CustomJumpJetDef.cs
@@ -26,6 +26,8 @@ namespace CustomComponents
         {
             return JSONSerializationUtility.ToJSON<T>(this as T);
         }
+
+        public Type TooltipType => TooltipHelper.GetTooltipType(new JumpJetDef());
     }
 
     [Custom("CategoryJumpJet")]

--- a/source/CustomTypes/CustomUpgrade.cs
+++ b/source/CustomTypes/CustomUpgrade.cs
@@ -1,4 +1,5 @@
-﻿using BattleTech;
+﻿using System;
+using BattleTech;
 using BattleTech.UI;
 using HBS.Util;
 
@@ -23,6 +24,8 @@ namespace CustomComponents
         {
             return JSONSerializationUtility.ToJSON<T>(this as T);
         }
+
+        public Type TooltipType => TooltipHelper.GetTooltipType(new UpgradeDef());
     }
 
     [Custom("CategoryUpgrade")]

--- a/source/CustomTypes/CustomWeaponDef.cs
+++ b/source/CustomTypes/CustomWeaponDef.cs
@@ -1,5 +1,7 @@
-﻿using BattleTech;
+﻿using System;
+using BattleTech;
 using BattleTech.UI;
+using BattleTech.UI.Tooltips;
 using HBS.Util;
 
 namespace CustomComponents
@@ -23,6 +25,8 @@ namespace CustomComponents
         {
             return JSONSerializationUtility.ToJSON<T>(this as T);
         }
+
+        public Type TooltipType => TooltipHelper.GetTooltipType(new WeaponDef());
     }
 
     [Custom("CategoryWeapon")]

--- a/source/Tooltips.cs
+++ b/source/Tooltips.cs
@@ -1,0 +1,60 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using BattleTech;
+using BattleTech.UI.Tooltips;
+using Harmony;
+
+namespace CustomComponents
+{
+    public static class TooltipHelper
+    {
+        public static Type GetTooltipType(MechComponentDef def)
+        {
+            var defHandler = TooltipUtilities.MechComponentDefHandlerForTooltip(def) as MechComponentDef;
+            return defHandler?.GetType();
+        }
+    }
+
+    [HarmonyPatch(typeof(TooltipManager), "SetActiveTooltip")]
+    public static class TooltipManagerSetActiveTooltipPatch
+    {
+        private static ICustomComponent customComponent;
+
+        public static void Prefix(object data)
+        {
+            customComponent = data as ICustomComponent;
+        }
+
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            return instructions
+                .MethodReplacer(
+                    AccessTools.Property(typeof(MemberInfo), "Name").GetGetMethod(),
+                    AccessTools.Method(typeof(TooltipManagerSetActiveTooltipPatch), "OverrideName")
+                );
+        }
+
+        public static void Postfix()
+        {
+            customComponent = null;
+        }
+
+        public static string OverrideName(this MemberInfo @this)
+        {
+            var name = customComponent == null ? @this.Name : customComponent.TooltipType.Name;
+            return name;
+        }
+    }
+
+    [HarmonyPatch(typeof(TooltipUtilities), "MechComponentDefHandlerForTooltip")]
+    public static class TooltipUtilitiesMechComponentDefHandlerForTooltipPatch
+    {
+        public static bool Prefix(MechComponentDef baseDef, ref object __result)
+        {
+            __result = baseDef as ICustomComponent;
+            return __result == null;
+        }
+    }
+}


### PR DESCRIPTION
- tooltips wont display on custom type, HBS has hardcoded typeof().equals(typeof()) checks
- regex fix for customtype to allow better json support