### PR TITLE
Category.OnItemGrabbed should respect maximum limits

### DIFF
--- a/source/Categories/Category.cs
+++ b/source/Categories/Category.cs
@@ -295,6 +295,35 @@ namespace CustomComponents
         public void OnItemGrabbed(IMechLabDraggableItem item, MechLabPanel mechLab, MechLabLocationWidget widget)
         {
             Control.LogDebug(DType.ComponentInstall, $"- Category {CategoryID}");
+            Control.LogDebug(DType.ComponentInstall, $"-- MaxEquiped: {CategoryDescriptor.MaxEquiped}");
+            Control.LogDebug(DType.ComponentInstall, $"-- MaxEquipedPerLocation: {CategoryDescriptor.MaxEquipedPerLocation}");
+            Control.LogDebug(DType.ComponentInstall, $"-- search replace for {item.ComponentRef.ComponentDefID}");
+
+            if (CategoryDescriptor.MaxEquiped > 0)
+            {
+                var countTotal = mechLab.activeMechDef.Inventory.Count(i => i.Def.IsCategory(CategoryID));
+                Control.LogDebug(DType.ComponentInstall, $"-- countTotal: {countTotal}");
+
+                if (countTotal >= CategoryDescriptor.MaxEquiped)
+                {
+                    Control.LogDebug(DType.ComponentInstall, $"-- no replacement, would exceed MaxEquiped");
+                    return;
+                }
+            }
+
+            if (CategoryDescriptor.MaxEquipedPerLocation > 0)
+            {
+                var countLocation = new LocationHelper(widget).LocalInventory.Count(i => i.ComponentRef.Def.IsCategory(CategoryID));
+                Control.LogDebug(DType.ComponentInstall, $"-- countLocation: {countLocation}");
+
+                if (countLocation >= CategoryDescriptor.MaxEquipedPerLocation)
+                {
+                    Control.LogDebug(DType.ComponentInstall, $"-- no replacement, would exceed MaxEquipedPerLocation");
+                    return;
+                }
+            }
+
+            Control.LogDebug(DType.ComponentInstall, $"- Category {CategoryID}");
             Control.LogDebug(DType.ComponentInstall, $"-- search replace for {item.ComponentRef.ComponentDefID}");
 
             var replace = DefaultFixer.Shared.GetReplaceFor(mechLab.activeMechDef, CategoryID, widget.loadout.Location, mechLab.sim);


### PR DESCRIPTION
- Check total count against MaxEquiped before replacing
- Check location count against MaxEquipedPerLocation before replacing

Basically, if there were already too many items of the category present, then grabbing one will not cause a replacement to be added.

It's mainly useful when game updates affect existing 'Mechs, like for example https://github.com/BattletechModders/RogueTech/pull/236, where a component got its missing Cockpit category added. With this change, you can just remove the extra cockpit, rather than having to send the 'Mech to storage to fix it.