### PR TITLE
Adds option that allows to use MechTags in TagsRestriction configs.

### DIFF
--- a/source/CustomComponents/CustomComponentSettings.cs
+++ b/source/CustomComponents/CustomComponentSettings.cs
@@ -162,6 +162,7 @@ public class CustomComponentSettings
     public bool FixDefaults = true;
     public bool TagRestrictionDropValidateRequiredTags = false;
     public bool TagRestrictionDropValidateIncompatibleTags = true;
+    public bool TagRestrictionUseMechTags = false;
     public bool CheckCriticalComponent = true;
     public bool UseDefaultFixedColor = false;
     public bool AddWeightToCategory = true;

--- a/source/CustomComponents/TagRestrictions/TagsChecker.cs
+++ b/source/CustomComponents/TagRestrictions/TagsChecker.cs
@@ -21,6 +21,11 @@ internal class TagsChecker
         chassisDef = mechDef.Chassis;
         inventory = mechDef.Inventory.ToList();
 
+        if (Control.Settings.TagRestrictionUseMechTags)
+        {
+            tagsOnMech.UnionWith(mechDef.MechTags);
+        }
+
         CollectChassisTags();
         CollectComponentTags();
     }


### PR DESCRIPTION
Originally, tags for TagsRestrictions looked up in chassis tags, component tags and categories. This PR adds option that enables use MechTags too for tags based restrictions. Disabled by default due potential performance hit in case of significant size of MechDef tag sets.